### PR TITLE
Update to work with @babel 7.0.0-beta.34 packages

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,9 @@
 {
-	"presets": ["es2015"],
+  "presets": [
+    ["@babel/preset-env", {
+      "targets": {
+        "node": "6.0"
+      }
+    }]
+  ]
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{.eslintrc,package.json}]
+[{.eslintrc,package.json,.babelrc}]
 indent_style = space
 indent_size = 2

--- a/main.es2015.js
+++ b/main.es2015.js
@@ -1,4 +1,4 @@
-import {addNamed} from 'babel-helper-module-imports';
+import {addNamed} from '@babel/helper-module-imports';
 
 export default function promiseToBluebird({types: t}) {
 	return {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "Transforms *Promise* to *bluebird*",
   "main": "main.es5.js",
   "devDependencies": {
-    "babel-cli": "^7.0.0-beta",
-    "babel-preset-es2015": "^7.0.0-beta"
+    "@babel/cli": "^7.0.0-beta.34",
+    "@babel/core": "^7.0.0-beta.34",
+    "@babel/preset-env": "^7.0.0-beta.34"
   },
   "dependencies": {
-    "babel-helper-module-imports": "^7.0.0-beta"
+    "@babel/helper-module-imports": "^7.0.0-beta.34"
   },
   "scripts": {
     "prepublish": "babel main.es2015.js --out-file main.es5.js --source-maps"


### PR DESCRIPTION
This PR fixes compatibility with the  `@babel` v7.0.0-beta.34 packages

You may want to adjust the value for `targets` in `.babelrc` I've put node 6.0 there, but maybe you want to support older version also, or more recent versions only?

You can read more about `@babel/preset-env` [here](https://github.com/babel/babel/tree/master/packages/babel-preset-env)